### PR TITLE
Handle missing posts gracefully

### DIFF
--- a/app/itinerario/[slug]/page.tsx
+++ b/app/itinerario/[slug]/page.tsx
@@ -1,8 +1,11 @@
 import { getPost } from '@/lib/posts';
 import { MDXRemote } from 'next-mdx-remote/rsc';
+import { notFound } from 'next/navigation';
 
 export default function PostPage({ params }: { params: { slug: string } }) {
-  const { meta, content } = getPost(params.slug);
+  const post = getPost(params.slug);
+  if (!post) notFound();
+  const { meta, content } = post;
   return (
     <article className="prose prose-invert max-w-none">
       <h1>{meta.title}</h1>

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -16,8 +16,9 @@ export function getAllPosts(): Post[] {
   }).sort((a,b) => (a.meta.date || '').localeCompare(b.meta.date || ''));
 }
 
-export function getPost(slug: string) {
+export function getPost(slug: string): { meta: any; content: string } | null {
   const full = path.join(contentDir, `${slug}.mdx`);
+  if (!fs.existsSync(full)) return null;
   const { data, content } = matter(fs.readFileSync(full, 'utf8'));
   return { meta: data as any, content };
 }


### PR DESCRIPTION
## Summary
- Return `null` from `getPost` when a post file doesn't exist
- Display a 404 page for unknown itinerary slugs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unexpected token in MapIceland.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_689b7ba77cf48331ad8d8ed8af69c752