### PR TITLE
Fix MapIceland useMemo type to prevent parsing error

### DIFF
--- a/components/MapIceland.tsx
+++ b/components/MapIceland.tsx
@@ -88,7 +88,7 @@ export default function MapIceland() {
     return () => clearInterval(id);
   }, [roadRoute]);
 
-  const position = useMemo<Pt>(() => (roadRoute?.[idx] || [64.8, -18]) as Pt, [roadRoute, idx]);
+  const position = useMemo(() => (roadRoute?.[idx] || [64.8, -18]) as Pt, [roadRoute, idx]) as Pt;
 
   return (
     <div className="rounded-2xl overflow-hidden shadow-xl border border-gray-800">


### PR DESCRIPTION
## Summary
- avoid `useMemo<Pt>` generic that triggered JSX parse error

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_689b7ef76ad0833181a960b879bf5257